### PR TITLE
Add github templates from the aerogear standards  to the repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at #aerogear channel on freenode IRC or via aerogear@googlegroups.com, see [AeroGear forum](https://groups.google.com/forum/#!forum/aerogear). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+For more information about the AeroGear community and project , visit [our website](https://aerogear.org/community/).
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# How to contribute
+
+Thank you for your interest in contributing to the AeroGear project. We want
+keep this process as easy as possible so we've outlined a few guidelines below. 
+For more information about the AeroGear community and project , visit 
+[our website](https://aerogear.org/community/).
+
+## Asking for help
+
+Whether you're contributing a new feature or bug fix, or simply submitting a ticket, the AeroGear team is available for technical advice or feedback. 
+You can reach us at #aerogear on [Freenode IRC](https://freenode.net/) or join the  [mailing list](https://groups.google.com/forum/#!forum/aerogear)
+-- both are actively monitored.
+
+## Getting started
+
+* Make sure you have a [JIRA account](https://issues.jboss.org)
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Submit a ticket for your issue to the 
+[AeroGear project]("https://issues.jboss.org/projects/AEROGEAR), assuming one does 
+not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug.
+  * Make sure you fill in the earliest version that you know has the issue.
+* Fork the repository on GitHub.
+
+## Making changes
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * To quickly create a topic branch based on master; `git checkout -b
+    <branch name> master`. By convention we typically include the JIRA issue 
+    key in the branch name, e.g. `AEROGEAR-1234-my-feature`.
+  * Please avoid working directly on the `master` branch.
+* Make commits of logical units.
+* Prepend your commit messages with a JIRA ticket number, e.g. "AEROGEAR-1234: Fix
+  spelling mistake in README."
+* Follow the coding style in use.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure you have added the necessary tests for your changes.
+* Run _all_ the tests to assure nothing else was accidentally broken.
+
+## Submitting changes
+
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request to the repository in the [AeroGear GitHub organization]
+  (https://github.com/aerogear) and choose branch you want to patch 
+  (usually master). 
+  * Advanced users may want to install the [GitHub CLI](https://hub.github.com/) 
+    and use the `hub pull-request` command.
+* Update your JIRA ticket to mark that you have submitted code and are ready 
+for it to be reviewed (Status: Dev Complete).
+  * Include a link to the pull request in the ticket.
+* Add detail about the change to the pull request including screenshots 
+  if the change affects the UI.
+
+## Reviewing changes
+
+* After submitting a pull request, one of AeroGear team members will review it.
+* Changes may be requested to conform to our style guide and internal 
+  requirements.
+* When the changes are approved and all tests are passing, a AeroGear team
+  member will merge them.
+* Note: if you have write access to the repository, do not directly merge pull 
+  requests. Let another team member review your pull request and approve it.
+
+# Additional Resources
+
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](https://help.github.com/articles/about-pull-requests/)
+* [Read the Issue Guidelines by @necolas](https://github.com/necolas/issue-guidelines/blob/master/CONTRIBUTING.md) for more details

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+Add a brief and meaningful description.
+
+## Expected Behavior
+Describe the expected behaviour. 
+
+## Actual Behavior
+Describe the current/actual behaviour.
+
+## Environment
+
+* Operating system:
+* OpenShift versions:
+* Project Versions: 
+
+## Steps to reproduce
+Describe all steps and pre-requirements which are required to be performed in order to reproduce this scenario. ( E.g 1. Action, 2. Action ... )

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Motivation
+Add references to relevant tickets or a short description about what motivated you do it. (E.g JIRA: https://issues.jboss.org/browse/AEROGEAR-{} AND/OR ISSUE: https://github.com/aerogear/standards/issues/{}) 
+
+## What
+Add an short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.)
+
+## Why
+Add an short answer for: Why it was done? (E.g The feature X was deprecated.)
+
+## How
+Add an short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) 
+
+## Verification Steps
+Add the steps required to check this change. Following an example.
+ 
+1. Go to `XX >> YY >> SS`
+2. Create a new item `N` with the info `X`
+3. Try to edit this item 
+4. Check if in the left menu the feature X is not so long present.
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member 
+
+## Progress
+
+- [x] Finished task
+- [ ] TODO
+
+## Additional Notes
+
+PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
+ 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8366

## What
Add GitHub templates from the [aerogear standards](https://github.com/aerogear/standards) to this new repo

## Why
Consistent issue and PR templates across aerogear

## Progress

- [x] Finished task
- [ ] TODO
 
