### PR TITLE
Add swagger API documention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # mobile-security-service-server
+
+## Viewing the API documentation
+1. Setup Swagger-UI locally
+    * Option 1: Install the Swagger-UI Chrome extension (https://chrome.google.com/webstore/detail/swagger-ui-console/ljlmonadebogfjabhkppkoohjkjclfai?hl=en)
+    * Option 2: Using docker. Run `docker run -p 80:8080 swaggerapi/swagger-ui` and `open localhost`
+2. Paste https://github.com/aerogear/mobile-security-service-server/blob/master/apispec.yaml and hit explore

--- a/apispec.yaml
+++ b/apispec.yaml
@@ -1,0 +1,199 @@
+---
+swagger: "2.0"
+info:
+  description: This is a sample mobile security service server.
+  version: 1.0.0
+  title: Mobile Security Service Server API
+  contact:
+    email: dffrench@redhat.com
+tags:
+- name: apps
+  description: All app endpoints
+schemes:
+- https
+- http
+paths:
+  /apps:
+    get:
+      tags:
+      - apps
+      summary: Retrieve list of apps
+      description: 'Returns root level information for all apps '
+      operationId: getApps
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Apps'
+  /apps/{appId}:
+    get:
+      tags:
+      - apps
+      summary: Get app by appId
+      description: Retrieve all information for a single app including all child information
+      operationId: getAppById
+      produces:
+      - application/json
+      parameters:
+      - name: appId
+        in: path
+        description: The id for the app that needs to be fetched.
+        required: true
+        type: string
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/App'
+        400:
+          description: Invalid appId supplied
+        404:
+          description: App not found
+    put:
+      tags:
+      - apps
+      summary: Update app by id
+      description: Update a single app using the app id, including updating version information
+      operationId: updateApp
+      produces:
+      - application/json
+      parameters:
+      - name: appId
+        in: path
+        description: The id for the app that needs to be updated.
+        required: true
+        type: string
+      - in: body
+        name: body
+        description: Updated app object
+        required: true
+        schema:
+          $ref: '#/definitions/App'
+      responses:
+        200:
+          description: successful operation
+        400:
+          description: Invalid app supplied
+        404:
+          description: App not found
+  /apps/{appId}/init:
+    post:
+      tags:
+      - apps
+      summary: Init call from sdk
+      description: Capture metrics from device and return if the app version they are using is disabled and has a set disabled message
+      operationId: initAppFromDevice
+      produces:
+      - application/json
+      parameters:
+      - name: appId
+        in: path
+        description: The id for the app.
+        required: true
+        type: string
+      - in: body
+        name: body
+        description: Updated app object
+        required: true
+        schema:
+          $ref: '#/definitions/AppInit'
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/AppInitResponse'
+        400:
+          description: Invalid appId supplied
+        404:
+          description: App not found
+definitions:
+  Apps:
+    type: array
+    items:
+      $ref: '#/definitions/Apps_inner'
+  App:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      appId:
+        type: integer
+        format: int64
+      appName:
+        type: string
+      disabled:
+        type: boolean
+        default: false
+      disabledMessage:
+        type: string
+      deployedVersions:
+        type: array
+        items:
+          $ref: '#/definitions/DeployedVersion'
+  DeployedVersion:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      version:
+        type: string
+      numOfClients:
+        type: integer
+        format: int64
+      numOfAppStartups:
+        type: integer
+        format: int64
+      disabled:
+        type: boolean
+        default: false
+      disabledMessage:
+        type: string
+  AppInit:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      version:
+        type: string
+      deviceType:
+        type: string
+      deviceVersion:
+        type: string
+      deviceId:
+        type: string
+  AppInitResponse:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      disabled:
+        type: boolean
+        default: false
+      disabledMessage:
+        type: string
+  Apps_inner:
+    properties:
+      id:
+        type: integer
+        format: int64
+      appId:
+        type: integer
+        format: int64
+      appName:
+        type: string
+      numOfDeployedVersions:
+        type: integer
+        format: int64
+      numOfClients:
+        type: integer
+        format: int64
+      numOfAppLaunches:
+        type: integer
+        format: int64


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8352

## What
Add Open API documentation for the currently mapped API endpoints

## Why
Useful as a reference for anyone on the team to view what is required for each endpoint

## How
Adding yaml spec to the root of the directory with steps to setup swagger-ui locally and view the documentation.

## Verification Steps 
1. Setup Swagger-UI locally
    * Option 1: Install the Swagger-UI Chrome extension (https://chrome.google.com/webstore/detail/swagger-ui-console/ljlmonadebogfjabhkppkoohjkjclfai?hl=en)
    * Option 2: Using docker. Run `docker run -p 80:8080 swaggerapi/swagger-ui` and `open localhost`
2. Paste https://raw.githubusercontent.com/davidffrench/mobile-security-service-server/AEROGEAR-8352/apispec.yaml in and hit explore

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
