### PR TITLE
[AEROGEAR-8389] Add option to use environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PORT=3000
+
+# Logging
+LOG_LEVEL=info
+LOG_FORMAT=text

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .vscode
 debug
+.env

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:ecd9aa82687cf31d1585d4ac61d0ba180e42e8a6182b85bd785fcca8dfeefc1b"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -95,6 +103,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/joho/godotenv",
     "github.com/labstack/echo",
     "github.com/sirupsen/logrus",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,3 +17,7 @@
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/joho/godotenv"
+  version = "1.3.0"

--- a/cmd/mobile-security-service-server/main.go
+++ b/cmd/mobile-security-service-server/main.go
@@ -1,18 +1,27 @@
 package main
 
 import (
+	dotenv "github.com/joho/godotenv"
 	"github.com/aerogear/mobile-security-service-server/pkg/config"
 	"github.com/labstack/echo"
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func init() {
 	config := config.Get()
-	e := echo.New()
 
 	initLogger(config.LogLevel, config.LogFormat)
 
-	log.WithFields(log.Fields{"listenAddress": config.ListenAddress}).Info("Starting application")
+	err := dotenv.Load()
+
+	if err != nil {
+		log.Info("No .env file found, using default values instead.")
+	}
+}
+
+func main() {
+	config := config.Get()
+	e := echo.New()
 
 	// start webserver
 	if err := e.Start(config.ListenAddress); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	defaultConfig := Config{
+		ListenAddress: ":3000",
+		LogLevel:      "info",
+		LogFormat:     "text",
+	}
+
+	tests := []struct {
+		name    string
+		want    Config
+		envVars map[string]string
+	}{
+		{
+			name: "Get() should return sensible defaults when no environment variables are set",
+			want: defaultConfig,
+		},
+		{
+			name: "Get() should override defaults with environment variables when set",
+			want: Config{
+				ListenAddress: ":4000",
+				LogLevel:      "error",
+				LogFormat:     "json",
+			},
+			envVars: map[string]string{
+				"PORT":       "4000",
+				"LOG_LEVEL":  "error",
+				"LOG_FORMAT": "json",
+			},
+		},
+		{
+			name: "Get() should return sensible defaults when empty environment variables are set",
+			want: defaultConfig,
+			envVars: map[string]string{
+				"PORT":       "",
+				"LOG_LEVEL":  "",
+				"LOG_FORMAT": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		if len(tt.envVars) != 0 {
+			for key, val := range tt.envVars {
+				os.Setenv(key, val)
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Get(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getEnv(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		want   string
+		envVar string
+	}{
+		{
+			name: "getEnv() should return default value when no environment variable is set",
+			args: args{"LOG_FORMAT", "json"},
+			want: "json",
+		},
+		{
+			name:   "getEnv() should return environment variable value when set instead of default value",
+			args:   args{"LOG_FORMAT", "json"},
+			envVar: "text",
+			want:   "text",
+		},
+	}
+	for _, tt := range tests {
+		if len(tt.envVar) > 0 {
+			os.Setenv(tt.args.key, tt.envVar)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEnv(tt.args.key, tt.args.defaultVal); got != tt.want {
+				t.Errorf("getEnv() = %v, want %v", got, tt.want)
+			}
+			os.Setenv(tt.envVar, "")
+		})
+
+	}
+}
+
+func Test_getEnvInt(t *testing.T) {
+	type args struct {
+		name       string
+		defaultVal int
+	}
+	tests := []struct {
+		name   string
+		args   args
+		want   int
+		envVar string
+	}{
+		{
+			name: "getEnvInt() should return default value when no environment variable is set",
+			args: args{"PORT", 3000},
+			want: 3000,
+		},
+		{
+			name:   "getEnvInt() should return environment variable value when set instead of default value",
+			args:   args{"PORT", 3000},
+			want:   5000,
+			envVar: "5000",
+		},
+		{
+			name:   "getEnvInt() should return default values variable when non-integer variables are set",
+			args:   args{"PORT", 3000},
+			want:   3000,
+			envVar: "three thousand",
+		},
+	}
+	for _, tt := range tests {
+		if len(tt.envVar) > 0 {
+			os.Setenv(tt.args.name, tt.envVar)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getEnvInt(tt.args.name, tt.args.defaultVal); got != tt.want {
+				t.Errorf("getEnvInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8389

## What

Add option to use environment variables instead of the defaults from config file.

## Why

Configurations can be modified without affecting the checked in codebase.

## How

1. Used [joho/godotenv](https://github.com/joho/godotenv) library
2. Load environment variables in `init()` function in `main.go`

## Verification Steps
 
Make a copy of the example `.env` file in the project root:

```sh
cp .env .env.example
```

Modify any value in `.env`. In this example I am going to change the port for the server to run on:

```.env
...
PORT=6000
...
```

Run the server:

```sh
go run cmd/mobile-security-service-server/main.go
```

Check the output from the terminal. It should show that the server is running on port 6000.

```
⇨ http server started on [::]:6000
```

Override the value in `.env` with a system environment variable:

```sh
export PORT=6001
```

Run the server again and you should see that it is now running on port 6001.

## Checklist:

- [ x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

I have also added unit tests for the `config.go`.
 
