### PR TITLE
AEROGEAR-8395 - Add Dockerfile and Docker Compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 .vscode
 debug
 .env
+mobile-security-service-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7
+ARG BINARY=./mobile-security-service-server
+EXPOSE 3000
+
+COPY ${BINARY} /opt/mobile-security-service-server
+ENTRYPOINT ["/opt/mobile-security-service-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+  db:
+    image: registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRESQL_PASSWORD: postgres
+      POSTGRESQL_USER: postgresql
+      POSTGRESQL_DATABASE: aerogear_mobile_security_service
+  api:
+    build:
+      context: .
+      args:
+        BINARY: ./mobile-security-service-server
+    environment:
+      PGHOST: db
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: aerogear_mobile_security_service
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db


### PR DESCRIPTION
## Motivation

JIRA: https://issues.jboss.org/browse/AEROGEAR-8395

## What

Created a `Dockerfile` and `docker-compose`.

## Why

So that users can run the mobile security server in a container without having to configure an environment.

## How

Copied the `Dockerfile` and `docker-compose` files from [https://github.com/aerogear/aerogear-app-metrics](https://github.com/aerogear/aerogear-app-metrics) and modified to suit this application.

## Verification Steps
 
1. Ensure you have `Docker` and `docker-compose` installed and running on your machine.
2. Generate the binary file for the application:

```sh
go build -o mobile-security-service-server cmd/mobile-security-service-server/main.go
```

3. Run the following:

```sh
docker-compose up -d
```

4. Check if your API and database containers are running:

```sh
> docker ps
CONTAINER ID        IMAGE                                                         COMMAND                  CREATED             STATUS              PORTS                    NAMES
d20c53a75ab9        mobile-security-service-server_api                            "/opt/mobile-secur..."   8 seconds ago       Up 8 seconds        0.0.0.0:3000->3000/tcp   mobile-security-service-server_api_1
55c53bbf98cb        registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest   "container-entrypo..."   9 seconds ago       Up 8 seconds        0.0.0.0:5432->5432/tcp   mobile-security-service-server_db_1
```

5. Go to `http://localhost:3000` in your browser. Do you get a valid HTTP response? For example:

```json
{
    "message": "Not Found"
}
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
